### PR TITLE
Added main category to XDF desktop file.

### DIFF
--- a/rtlsdr-scanner.desktop
+++ b/rtlsdr-scanner.desktop
@@ -3,4 +3,4 @@ Type = Application
 Name = RTLSDR Scanner
 Comment = A cross platform Python frequency scanning GUI for the OsmoSDR rtl-sdr library
 Exec = python -m rtlsdr_scanner
-Categories = HamRadio;
+Categories = Utility;HamRadio;


### PR DESCRIPTION
This ensure it is placed in a sensible place in the menu also if the non-official HamRadio category is unknown.

Based on a patch from Sophie Brun and the Kali project.