### PR TITLE
Introduced application/vnd.rtlsdr-scanner+json for scan save files

### DIFF
--- a/rtlsdr-scanner.desktop
+++ b/rtlsdr-scanner.desktop
@@ -4,3 +4,4 @@ Name = RTLSDR Scanner
 Comment = A cross platform Python frequency scanning GUI for the OsmoSDR rtl-sdr library
 Exec = python -m rtlsdr_scanner
 Categories = HamRadio;
+MimeType=application/vnd.rtlsdr-scanner+json;

--- a/rtlsdr-scanner.mime
+++ b/rtlsdr-scanner.mime
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mime-type xmlns="http://www.freedesktop.org/standards/shared-mime-info" type="application/vnd.rtlsdr-scanner+json">
+  <comment>RTLSDR scanner document</comment>
+  <acronym>RFS</acronym>
+  <expanded-acronym>RTLSDR ? Scan</expanded-acronym>
+  <sub-class-of type="application/json"/>
+  <glob pattern="*.rfs"/>
+</mime-type>


### PR DESCRIPTION
This ensure the file browsers in Linux desktop environments understand these files belong to rtlsdr-scanner.

The mime type should also be registered with IANA, see <URL: https://www.iana.org/assignments/media-types/media-types.xhtml >.